### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -120,7 +120,7 @@ lightning.strike = function(pos)
 		texture = "lightning_lightning_" .. rng:next(1,3) .. ".png",
 	})
 
- 	minetest.sound_play({ pos = pos, name = "lightning_thunder", gain = 10, max_hear_distance = 500 }) 
+	minetest.sound_play({ pos = pos, name = "lightning_thunder", gain = 10, max_hear_distance = 500 })
 
 	-- damage nearby objects, player or not
 	for _, obj in ipairs(minetest.get_objects_inside_radius(pos, 5)) do

--- a/init.lua
+++ b/init.lua
@@ -125,7 +125,7 @@ lightning.strike = function(pos)
 	-- damage nearby objects, player or not
 	for _, obj in ipairs(minetest.get_objects_inside_radius(pos, 5)) do
 		-- nil as param#1 is supposed to work, but core can't handle it.
-		obj:punch(obj, 1.0, {full_punch_interval = 1.0, damage_groups = {fleshy=8}}, nil) 
+		obj:punch(obj, 1.0, {full_punch_interval = 1.0, damage_groups = {fleshy=8}}, nil)
 	end
 
 	local playerlist = minetest.get_connected_players()


### PR DESCRIPTION
Changes:
    Fixes a bug that would leave the player's sky permanently white after two lightning strikes occur in rapid succession.
    Adds ability to optionally specify the strength of a lightning strike (light, medium, heavy), with a default of "light".
    Adds variation in the damage a player takes based on how close he is to the strike point.