### PR TITLE
[code cleanup] Fix player ref

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,19 @@
+
+globals = {
+	"lightning"
+}
+
+read_globals = {
+	-- Stdlib
+	string = {fields = {"split"}},
+	table = {fields = {"copy", "getn"}},
+	"PcgRandom",
+
+	-- Minetest
+	"minetest",
+	"vector", "ItemStack",
+	"dump",
+
+	-- mods
+	"default", "fire"
+}

--- a/init.lua
+++ b/init.lua
@@ -34,7 +34,7 @@ local revertsky = function()
 		return
 	end
 
-	for key, entry in pairs(ps) do
+	for _, entry in pairs(ps) do
 		local sky = entry.sky
 		entry.p:set_sky(sky.bgcolor, sky.type, sky.textures)
 	end
@@ -217,7 +217,7 @@ minetest.register_node("lightning:dying_flame", {
 })
 
 -- if other mods disable auto lightning during initialization, don't trigger the first lightning.
-minetest.after(5, function(dtime)
+minetest.after(5, function()
 	if lightning.auto then
 		minetest.after(rng:next(lightning.interval_low,
 			lightning.interval_high), lightning.strike)

--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@ lightning.auto = true
 
 local rng = PcgRandom(32321123312123)
 
+-- table with playername as key and previous skybox as value
 local ps = {}
 local ttl = 1
 
@@ -34,9 +35,12 @@ local revertsky = function()
 		return
 	end
 
-	for _, entry in pairs(ps) do
-		local sky = entry.sky
-		entry.p:set_sky(sky.bgcolor, sky.type, sky.textures)
+	for playername, sky in pairs(ps) do
+		local player = minetest.get_player_by_name(playername)
+		-- check if the player is still online
+		if player then
+			player:set_sky(sky.bgcolor, sky.type, sky.textures)
+		end
 	end
 
 	ps = {}
@@ -140,7 +144,7 @@ lightning.strike = function(pos)
 
 		local name = player:get_player_name()
 		if ps[name] == nil then
-			ps[name] = {p = player, sky = sky}
+			ps[name] = sky
 			player:set_sky(0xffffff, "plain", {})
 		end
 	end


### PR DESCRIPTION
This PR fixes the stored player reference:

Player objects should not be stored in the state, instead the playername is used
and the object is retrieved with `minetest.get_player_by_name()` and checked
if still online.

Also includes #12 