### PR TITLE
Use mod.conf for dependencies and description

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,0 @@
-default?
-fire?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-A mod that adds thunder and lightning effects.

--- a/init.lua
+++ b/init.lua
@@ -61,7 +61,7 @@ local function choose_pos(pos)
 
 		local r = rng:next(1, playercount)
 		local randomplayer = playerlist[r]
-		pos = randomplayer:getpos()
+		pos = randomplayer:get_pos()
 
 		-- avoid striking underground
 		if pos.y < -20 then

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,3 @@
 name = lightning
+optional_depends = default, fire
+description = A mod that adds thunder and lightning effects.


### PR DESCRIPTION
Replaces `getpos` with `get_pos`; replaces `depends.txt` and `description.txt` with `mod.conf`.