### PR TITLE
Add a setting to disable the random fire chance.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,8 @@ lightning.auto = true
 -- range of the skybox highlight and sound effect
 lightning.effect_range = 500
 
+local random_fire = minetest.settings:get_bool("lightning_random_fire") ~= false
+
 local rng = PcgRandom(32321123312123)
 
 -- table with playername as key and previous skybox as value
@@ -167,7 +169,7 @@ lightning.strike = function(pos)
 				return
 			end
 			-- very rarely, potentially cause a fire
-			if fire and rng:next(1,1000) == 1 then
+			if fire and random_fire and rng:next(1,1000) == 1 then
 				minetest.set_node(pos2, {name = "fire:basic_flame"})
 			else
 				minetest.set_node(pos2, {name = "lightning:dying_flame"})

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,5 +1,4 @@
-[Settings]
-# By default when fire is enabled lightning has a small chance to start
-# a fire. This value allows to disable the random fire chance even when
-# fire is enabled.
+# When fire is enabled, this setting specifies whether the lightnings
+# have a small chance to start a fire.
+# Value 'false' will disable fire caused by lightnings.
 lightning_random_fire (Enable random fire) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,5 @@
+[Settings]
+# By default when fire is enabled lightning has a small chance to start
+# a fire. This value allows to disable the random fire chance even when
+# fire is enabled.
+lightning_random_fire (Enable random fire) bool true


### PR DESCRIPTION
I may trust other players on a private server to not burn stuff down while I would not trust rng to not burn it down.